### PR TITLE
add: Agenda削除機能を追加

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -22,14 +22,8 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    # byebug
-    render :index if current_user != @agenda.user || current_user != @agenda.team.owner
-
+    @agenda.target_user = current_user
     if @agenda.destroy
-      @agenda.team.assigns.each do |assign|
-        email = assign.user.email
-        AgendaMailer.agenda_mail(email, @agenda).deliver
-      end
       redirect_to dashboard_path, notice: "アジェンダ「#{@agenda.title}」を削除しました！"
     else
       render :index

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -18,6 +18,21 @@ class AgendasController < ApplicationController
       redirect_to dashboard_url, notice: 'アジェンダ作成に成功しました！'
     else
       render :new
+    end
+  end
+
+  def destroy
+    # byebug
+    render :index if current_user != @agenda.user || current_user != @agenda.team.owner
+
+    if @agenda.destroy
+      @agenda.team.assigns.each do |assign|
+        email = assign.user.email
+        AgendaMailer.agenda_mail(email, @agenda).deliver
+      end
+      redirect_to dashboard_path, notice: "アジェンダ「#{@agenda.title}」を削除しました！"
+    else
+      render :index
     end
   end
 

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,9 @@
+class AgendaMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_mail(email, agenda)
+    @email = email
+    @agenda = agenda
+    mail to: @email, subject: 'Agenda削除通知'
+  end
+end

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -2,4 +2,20 @@ class Agenda < ApplicationRecord
   belongs_to :team
   belongs_to :user
   has_many :articles, dependent: :destroy
+
+  before_destroy :check_authority
+  after_destroy :send_delete_agenda_mail
+
+  attr_accessor :target_user
+
+  def check_authority
+    target_user == self.user || target_user == self.team.owner
+  end
+
+  def send_delete_agenda_mail
+    self.team.assigns.each do |assign|
+      email = assign.user.email
+      AgendaMailer.agenda_mail(email, self).deliver
+    end
+  end
 end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,5 @@
+<h1>あなたのチームのAgendaが削除されました！</h1>
+
+<h4>email: <%= @email %></h4>
+<h4>team: <%= @agenda.team.name %></h4>
+<h4>agenda: <%= @agenda.title %></h4>

--- a/app/views/agendas/index.html.erb
+++ b/app/views/agendas/index.html.erb
@@ -12,7 +12,10 @@
   <tbody>
     <% @agendas.includes(:articles).each do |agenda| %>
       <table>
-        <tr>Agenda title:<%= agenda.title %></tr>
+        <tr>
+          Agenda title:<%= agenda.title %>
+          <%= link_to 'Delete Agenda', agenda_path, method: :delete %>
+        </tr>
         <br />
         <% agenda.articles.each do |article| %>
           <li>Article title:<%= article.title %></li>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,16 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <p href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
-              <p>
-                <%= agenda.title %>
-                <i class="right fa fa-angle-left"></i>
-              </p>
-            </a>
+              <span><%= agenda.title %></span>
+              <span class="mx-3">
+                <% if current_user == agenda.user || current_user == @working_team.owner %>
+                  <%= link_to '削除', agenda_path(agenda), method: :delete %>
+                <% end %>
+              </span>
+              <a href="#"><i class="right fa fa-angle-left float-sm-right"></i></a>
+            </p>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
issue #5 
- [x] AgendasControllerのdestroyアクションを追加し、そこに機能追加する

- [x] Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される

- [x] Agendaに紐づいているarticleも一緒に削除される

- [x] Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ

- [x] Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ

- [x] 情報処理が完了した後はDashBoardに飛ぶ
